### PR TITLE
fix: framer-motion から motion/react への import 移行

### DIFF
--- a/src/components/chakra/Contact.tsx
+++ b/src/components/chakra/Contact.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box, Text, Link as ChakraLink } from '@chakra-ui/react'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { FaArrowRight } from 'react-icons/fa'
 import { theme } from './theme'
 import { useReveal } from './useReveal'

--- a/src/components/chakra/Contents.tsx
+++ b/src/components/chakra/Contents.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box, Flex, Text, SimpleGrid, Image, Link as ChakraLink } from '@chakra-ui/react'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { FaArrowRight } from 'react-icons/fa'
 import { theme } from './theme'
 import { useReveal } from './useReveal'

--- a/src/components/chakra/Header.tsx
+++ b/src/components/chakra/Header.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { Box, Flex, Text, Link as ChakraLink, HStack, VStack } from '@chakra-ui/react'
 import { FaGithub, FaBars, FaTimes } from 'react-icons/fa'
-import { motion, AnimatePresence } from 'framer-motion'
+import { motion, AnimatePresence } from 'motion/react'
 import { theme } from './theme'
 import { getContent } from '@/content'
 

--- a/src/components/chakra/Hero.tsx
+++ b/src/components/chakra/Hero.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box, Flex, Text, Image, Link as ChakraLink } from '@chakra-ui/react'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { FaGithub } from 'react-icons/fa'
 import { theme } from './theme'
 import { useReveal } from './useReveal'

--- a/src/components/chakra/Skills.tsx
+++ b/src/components/chakra/Skills.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box, Flex, Text, SimpleGrid } from '@chakra-ui/react'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
 import SectionLabel from './SectionLabel'

--- a/src/components/chakra/Timeline.tsx
+++ b/src/components/chakra/Timeline.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { Box, Text } from '@chakra-ui/react'
-import { motion } from 'framer-motion'
+import { motion } from 'motion/react'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
 import SectionLabel from './SectionLabel'

--- a/src/components/chakra/useReveal.ts
+++ b/src/components/chakra/useReveal.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useReducedMotion } from 'framer-motion'
+import { useReducedMotion } from 'motion/react'
 
 // スクロール時の控えめな出現アニメ。prefers-reduced-motion 有効時は無効化する。
 export function useReveal() {


### PR DESCRIPTION
## 概要

PR #101（Renovate）で依存パッケージが `framer-motion` から `motion` へ置換されましたが、ソースコードは引き続き `framer-motion` から直接 import しており、**`motion` パッケージの推移的依存**に依存した状態でした。現状は動作していますが、将来 `framer-motion` が推移的依存から外れると壊れるため、`motion/react` から import するよう修正します。

## 変更内容

以下7ファイルの import 元を `framer-motion` → `motion/react` に変更（`motion` / `AnimatePresence` / `useReducedMotion` は `motion/react` からエクスポートされていることを確認済み）:

- `src/components/chakra/Contact.tsx`
- `src/components/chakra/Contents.tsx`
- `src/components/chakra/Header.tsx`
- `src/components/chakra/Hero.tsx`
- `src/components/chakra/Skills.tsx`
- `src/components/chakra/Timeline.tsx`
- `src/components/chakra/useReveal.ts`

## 確認済み

- `npm run lint` / `npx tsc --noEmit` / `npm run build` 通過
- ローカルで実動作を確認（コンソールエラーなし、`whileInView` のスクロールアニメーションが正常動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhARrEUnhtgbMHUReFeKnZ