### PR TITLE
chore(deps): GitHub Actions と Node を最新へ更新（Renovate PR集約）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,16 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Install dependencies
         run: npm ci
@@ -50,4 +50,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## 概要

Renovate が開いていた未マージの依存更新PRを1つに集約しました。各PRは main に対して `BEHIND`（ブランチ保護の up-to-date 必須）で個別マージできなかったため、まとめて1回の CI・デプロイで反映します。

## 変更内容（`.github/workflows/ci.yml`, `deploy.yml`）

| Action / 項目 | 変更 | 元PR |
|---|---|---|
| actions/checkout | v4 → v7 | #100 |
| actions/setup-node | v4 → v6 | #54 |
| actions/configure-pages | v4 → v6 | #92 |
| actions/deploy-pages | v4 → v5 | #93 |
| node-version | 20 → 24 | #64 |

`actions/upload-pages-artifact` は対応する Renovate PR がないため v4 のまま。

## この PR マージ後の対応

集約済みの Renovate PR（#100 / #93 / #92 / #64 / #54）はクローズします。#54 は現存しない `gatsby.yml` を含む古い内容のため、いずれにせよマージ対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhARrEUnhtgbMHUReFeKnZ