### PR TITLE
feat(i18n): 英語版対応（URLパラメータ + ブラウザ言語判定）

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,38 +8,41 @@ import Skills from '@/components/chakra/Skills'
 import Timeline from '@/components/chakra/Timeline'
 import Contact from '@/components/chakra/Contact'
 import Footer from '@/components/chakra/Footer'
+import { LocaleProvider } from '@/components/chakra/LocaleContext'
 import { theme } from '@/components/chakra/theme'
 
 export default function Home() {
   return (
-    <Box
-      minH="100vh"
-      position="relative"
-      overflow="hidden"
-      style={{ backgroundColor: theme.bg, color: theme.text, fontFamily: theme.fontBody }}
-    >
-      {/* 極薄グリッドの質感（グロー/floatの代わり） */}
+    <LocaleProvider>
       <Box
-        position="fixed"
-        inset={0}
-        zIndex={0}
-        pointerEvents="none"
-        style={{ backgroundImage: theme.gridLines, backgroundSize: theme.gridSize }}
-      />
+        minH="100vh"
+        position="relative"
+        overflow="hidden"
+        style={{ backgroundColor: theme.bg, color: theme.text, fontFamily: theme.fontBody }}
+      >
+        {/* 極薄グリッドの質感（グロー/floatの代わり） */}
+        <Box
+          position="fixed"
+          inset={0}
+          zIndex={0}
+          pointerEvents="none"
+          style={{ backgroundImage: theme.gridLines, backgroundSize: theme.gridSize }}
+        />
 
-      <Box position="relative" zIndex={1}>
-        <Header />
+        <Box position="relative" zIndex={1}>
+          <Header />
 
-        <Box as="main" pt="61px">
-          <Hero />
-          <Contents />
-          <Skills />
-          <Timeline />
-          <Contact />
+          <Box as="main" pt="61px">
+            <Hero />
+            <Contents />
+            <Skills />
+            <Timeline />
+            <Contact />
+          </Box>
+
+          <Footer />
         </Box>
-
-        <Footer />
       </Box>
-    </Box>
+    </LocaleProvider>
   )
 }

--- a/src/components/chakra/Contact.tsx
+++ b/src/components/chakra/Contact.tsx
@@ -6,12 +6,12 @@ import { FaArrowRight } from 'react-icons/fa'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
 import SectionLabel from './SectionLabel'
-import { getContent } from '@/content'
+import { useContent } from './LocaleContext'
 
 const MotionBox = motion.create(Box)
 
 export default function Contact() {
-  const { contact } = getContent()
+  const { contact } = useContent()
   const reveal = useReveal()
 
   return (

--- a/src/components/chakra/Contents.tsx
+++ b/src/components/chakra/Contents.tsx
@@ -6,12 +6,12 @@ import { FaArrowRight } from 'react-icons/fa'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
 import SectionLabel from './SectionLabel'
-import { getContent } from '@/content'
+import { useContent } from './LocaleContext'
 
 const MotionBox = motion.create(Box)
 
 export default function Contents() {
-  const { works } = getContent()
+  const { works } = useContent()
   const reveal = useReveal()
 
   return (

--- a/src/components/chakra/Footer.tsx
+++ b/src/components/chakra/Footer.tsx
@@ -5,7 +5,7 @@ import type { IconType } from 'react-icons'
 import { FaGithub } from 'react-icons/fa'
 import { SiQiita, SiDevdotto } from 'react-icons/si'
 import { theme } from './theme'
-import { getContent } from '@/content'
+import { useContent } from './LocaleContext'
 
 const iconMap: Record<string, IconType> = {
   github: FaGithub,
@@ -14,7 +14,7 @@ const iconMap: Record<string, IconType> = {
 }
 
 export default function Footer() {
-  const { footer } = getContent()
+  const { footer } = useContent()
   const currentYear = new Date().getFullYear()
   const copyright = footer.copyright.replace('{year}', String(currentYear))
 

--- a/src/components/chakra/Header.tsx
+++ b/src/components/chakra/Header.tsx
@@ -5,12 +5,44 @@ import { Box, Flex, Text, Link as ChakraLink, HStack, VStack } from '@chakra-ui/
 import { FaGithub, FaBars, FaTimes } from 'react-icons/fa'
 import { motion, AnimatePresence } from 'motion/react'
 import { theme } from './theme'
-import { getContent } from '@/content'
+import { useContent, useLocale } from './LocaleContext'
+import { locales } from '@/content'
 
 const MotionBox = motion.create(Box)
 
+function LocaleToggle() {
+  const { locale, setLocale } = useLocale()
+  return (
+    <HStack gap={0} style={{ border: `1px solid ${theme.border}`, borderRadius: '4px' }} overflow="hidden">
+      {locales.map((l) => {
+        const active = l === locale
+        return (
+          <Box
+            as="button"
+            key={l}
+            onClick={() => setLocale(l)}
+            px={2.5}
+            py={1}
+            fontSize="xs"
+            fontFamily={theme.fontMono}
+            cursor="pointer"
+            aria-pressed={active}
+            aria-label={`Switch to ${l.toUpperCase()}`}
+            color={active ? theme.bg : theme.textSecondary}
+            style={{ backgroundColor: active ? theme.accent : 'transparent' }}
+            transition="color 0.2s, background-color 0.2s"
+            _hover={active ? undefined : { color: theme.accent }}
+          >
+            {l.toUpperCase()}
+          </Box>
+        )
+      })}
+    </HStack>
+  )
+}
+
 export default function Header() {
-  const content = getContent()
+  const content = useContent()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
@@ -61,6 +93,8 @@ export default function Header() {
           </HStack>
 
           <HStack gap={4}>
+            <LocaleToggle />
+
             <ChakraLink
               href={content.hero.githubUrl}
               target="_blank"

--- a/src/components/chakra/Hero.tsx
+++ b/src/components/chakra/Hero.tsx
@@ -5,12 +5,12 @@ import { motion } from 'motion/react'
 import { FaGithub } from 'react-icons/fa'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
-import { getContent } from '@/content'
+import { useContent } from './LocaleContext'
 
 const MotionBox = motion.create(Box)
 
 export default function Hero() {
-  const { hero } = getContent()
+  const { hero } = useContent()
   const reveal = useReveal()
   const nameLines = hero.name.split(' ')
 

--- a/src/components/chakra/LocaleContext.tsx
+++ b/src/components/chakra/LocaleContext.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { createContext, useContext, useState, useEffect, useCallback } from 'react'
+import type { ReactNode } from 'react'
+import { getContent, isLocale, defaultLocale } from '@/content'
+import type { Locale, SiteContent } from '@/content'
+
+interface LocaleContextValue {
+  locale: Locale
+  setLocale: (locale: Locale) => void
+}
+
+const LocaleContext = createContext<LocaleContextValue | null>(null)
+
+export function LocaleProvider({ children }: { children: ReactNode }) {
+  // 静的HTMLは常に既定(日本語)でレンダリングし、hydration後にクライアント側で判定して反映する。
+  const [locale, setLocaleState] = useState<Locale>(defaultLocale)
+
+  // 初回判定: URLパラメータ(?lang=) を最優先、なければブラウザ言語、どちらもなければ既定(ja)
+  useEffect(() => {
+    const param = new URLSearchParams(window.location.search).get('lang')
+    if (isLocale(param)) {
+      setLocaleState(param)
+      return
+    }
+    const browser = navigator.language?.toLowerCase() ?? ''
+    if (browser.startsWith('en')) {
+      setLocaleState('en')
+    }
+  }, [])
+
+  // <html lang> を現在の言語に同期（アクセシビリティ）
+  useEffect(() => {
+    document.documentElement.lang = locale
+  }, [locale])
+
+  // 言語切替時は URLパラメータ も更新して共有・リロード時に維持する
+  const setLocale = useCallback((next: Locale) => {
+    setLocaleState(next)
+    const url = new URL(window.location.href)
+    url.searchParams.set('lang', next)
+    window.history.replaceState(null, '', url.toString())
+  }, [])
+
+  return <LocaleContext.Provider value={{ locale, setLocale }}>{children}</LocaleContext.Provider>
+}
+
+export function useLocale(): LocaleContextValue {
+  const ctx = useContext(LocaleContext)
+  if (!ctx) throw new Error('useLocale must be used within a LocaleProvider')
+  return ctx
+}
+
+// 現在の言語に対応した文言を返す
+export function useContent(): SiteContent {
+  const { locale } = useLocale()
+  return getContent(locale)
+}

--- a/src/components/chakra/Skills.tsx
+++ b/src/components/chakra/Skills.tsx
@@ -5,7 +5,7 @@ import { motion } from 'motion/react'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
 import SectionLabel from './SectionLabel'
-import { getContent } from '@/content'
+import { useContent } from './LocaleContext'
 import skillData from '@/data/skillData'
 
 const MotionBox = motion.create(Box)
@@ -39,7 +39,7 @@ function SkillBar({ name, score, index }: { name: string; score: number; index: 
 }
 
 export default function Skills() {
-  const { skills } = getContent()
+  const { skills } = useContent()
   const reveal = useReveal()
 
   return (

--- a/src/components/chakra/Timeline.tsx
+++ b/src/components/chakra/Timeline.tsx
@@ -5,12 +5,12 @@ import { motion } from 'motion/react'
 import { theme } from './theme'
 import { useReveal } from './useReveal'
 import SectionLabel from './SectionLabel'
-import { getContent } from '@/content'
+import { useContent } from './LocaleContext'
 
 const MotionBox = motion.create(Box)
 
 export default function Timeline() {
-  const { timeline } = getContent()
+  const { timeline } = useContent()
   const reveal = useReveal()
 
   return (

--- a/src/content/en.json
+++ b/src/content/en.json
@@ -1,0 +1,194 @@
+{
+  "nav": [
+    { "label": "Works", "href": "#contents" },
+    { "label": "Skills", "href": "#skills" },
+    { "label": "Timeline", "href": "#timeline" },
+    { "label": "Contact", "href": "#contact" }
+  ],
+  "hero": {
+    "role": "Frontend Developer",
+    "name": "Takahiro Saeki",
+    "description": "Frontend development centered on React / TypeScript / Next.js. I love building things and creating animation-driven experiences.",
+    "ctaGithub": "GitHub",
+    "ctaContact": "Contact",
+    "githubUrl": "https://github.com/takahiro-saeki"
+  },
+  "works": {
+    "heading": "Works",
+    "items": [
+      {
+        "title": "Voices Diary",
+        "description": "An app to record and visualize your vocal training practice. Log your practice time, voice condition, and notes, and stay consistent with streaks and a heatmap. Supports tagging reference videos and syncs data between the web app and iOS app.",
+        "tag": "Web / iOS App",
+        "links": [
+          { "label": "Website", "url": "https://voicesdiary.com/" },
+          { "label": "App Store", "url": "https://apps.apple.com/jp/app/voices-diary/id6779493880" }
+        ]
+      },
+      {
+        "title": "SquadNote",
+        "description": "An app that simplifies running a club: schedule creation, one-tap attendance, invite-link joining, and monthly LINE sharing. Completely free with no ads.",
+        "tag": "Web / iOS App",
+        "links": [
+          { "label": "Website", "url": "https://squad-note.com/" },
+          { "label": "App Store", "url": "https://apps.apple.com/jp/app/squadnote/id6766142849" }
+        ]
+      },
+      {
+        "title": "Roll for Six",
+        "description": "An incremental clicker game where you roll six dice and keep matching sixes to progress. Features skill unlocks, boss battles, and an infinite mode, with full content playable in 60-90 minutes. Built with Godot Engine 4.x.",
+        "tag": "Godot / Game",
+        "links": [{ "label": "itch.io", "url": "https://tsgamestudio.itch.io/roll-for-six" }]
+      },
+      {
+        "title": "LOOP HAXE",
+        "description": "A hack-and-slash roguelike where you watch a horde of summoned beasts fight automatically. Choose your path through branching dungeons and build synergies from relics, beasts, and skills. A browser-playable game built with Godot.",
+        "tag": "Godot / Game",
+        "links": [{ "label": "itch.io", "url": "https://tsgamestudio.itch.io/loop-haxe" }]
+      },
+      {
+        "title": "Portfolio Site",
+        "description": "The portfolio site of me, Takahiro Saeki.",
+        "image": "/images/ts.png",
+        "tag": "Next.js",
+        "links": []
+      },
+      {
+        "title": "Mofumofu Paradise",
+        "description": "The official website of Mofumofu Paradise.",
+        "image": "/images/mohupara.png",
+        "tag": "Web",
+        "links": [{ "label": "View site", "url": "/mohupara" }]
+      }
+    ]
+  },
+  "skills": {
+    "heading": "Skills",
+    "categories": [
+      {
+        "key": "lang",
+        "title": "Languages",
+        "note": "Not listed here, but I'm also good with Node.js. I'm broadly strong with everything JavaScript-related."
+      },
+      {
+        "key": "framework",
+        "title": "Frameworks",
+        "note": "React is my strong suit. I often use react-redux for state management."
+      },
+      {
+        "key": "build",
+        "title": "Build Tools",
+        "note": "I choose tools by use case: webpack at work, and webpack or parcel for personal projects."
+      },
+      {
+        "key": "graphic",
+        "title": "Design Tools",
+        "note": "I mostly use Figma at work, and Photoshop for personal projects."
+      },
+      {
+        "key": "css",
+        "title": "CSS",
+        "note": "In React environments I mostly use styled-components, so it's mostly CSS-in-JS, but personally I prefer PostCSS."
+      },
+      {
+        "key": "ai",
+        "title": "AI",
+        "note": "I use AI-assisted development daily, centered on Claude Code. For my personal game projects, I also leverage AI for code generation and sound production."
+      },
+      {
+        "key": "others",
+        "title": "Others",
+        "note": "In my private time I've enjoyed using web components and following the spec. I get to use them occasionally at work too, and I'd like to use them more proactively."
+      }
+    ]
+  },
+  "timeline": {
+    "heading": "Timeline",
+    "items": [
+      {
+        "title": "Born into this world",
+        "date": "1991 -",
+        "desc": "After finishing high school entrance exams, I spent years in band life, focused on composing and playing live."
+      },
+      {
+        "title": "P.I.SQUARE",
+        "date": "2014-2014",
+        "desc": "Designed with Photoshop and built websites with HTML, CSS, and JavaScript."
+      },
+      {
+        "title": "Became a freelance engineer",
+        "date": "2015 -",
+        "desc": "Started as a sole proprietor, mainly building WordPress-based websites."
+      },
+      {
+        "title": "Renewal of an online reservation system",
+        "date": "2015 - 2015",
+        "desc": "Development using an in-house JavaScript framework. This work led me to start learning ECMAScript 2015."
+      },
+      {
+        "title": "SNS app development",
+        "date": "2016 - 2016",
+        "desc": "Mainly worked on implementing JavaScript animations."
+      },
+      {
+        "title": "Language study in Vancouver",
+        "date": "2016 - 2016",
+        "desc": "Studied English in Canada while attending meetups almost every week, connecting with local engineers. Through my hobby DanceDanceRevolution, I made 20-30 friends in the Vancouver DDR community."
+      },
+      {
+        "title": "Frontend work for an e-book service",
+        "date": "2017 - 2017",
+        "desc": "After returning to Japan, I focused on frontend implementation to improve an e-book service at a company. I also hosted weekly in-house study sessions, helping raise the team's frontend skills."
+      },
+      {
+        "title": "Togetter",
+        "date": "2017 - 2018",
+        "desc": "App development with React Native + Redux + redux-saga. My first production experience using Redux, which deepened my understanding of the Redux ecosystem."
+      },
+      {
+        "title": "SmartDrive",
+        "date": "2018 - 2019",
+        "desc": "Development with React/Redux. Maintained and implemented new features for medium-to-large-scale applications."
+      },
+      {
+        "title": "BLUB Inc.",
+        "date": "2018 - 2019",
+        "desc": "New app development with React Native, along with various smaller implementations."
+      },
+      {
+        "title": "HRBrain",
+        "date": "2019 - 2021",
+        "desc": "Mainly maintained and developed new features for medium-to-large React/Redux applications."
+      },
+      {
+        "title": "Ikyu Corporation",
+        "date": "2021 - 2023",
+        "desc": "Developed a new web service with Next.js, and built its app version using Expo (React Native)."
+      },
+      {
+        "title": "CureApp, Inc.",
+        "date": "2022 - 2024",
+        "desc": "Maintained iOS/Android apps built with React Native, and maintained and implemented web services with Next.js."
+      }
+    ]
+  },
+  "contact": {
+    "heading": "Contact",
+    "body": "Please reach out via the Google Form below. Feel free to contact me for work inquiries or any questions.",
+    "button": "Open Google Form",
+    "formUrl": "https://forms.gle/wDGveE76AfxXXASz9"
+  },
+  "footer": {
+    "name": "Hiro",
+    "role": "Frontend Developer",
+    "bio": "Takahiro Saeki, a frontend engineer by trade. Once I'm convinced something is right, I go all in. My hobbies are rhythm games, working out, and reading. I love cats.",
+    "linksHeading": "External Links",
+    "copyright": "© 2015-{year} Takahiro Saeki",
+    "links": [
+      { "label": "Mofupara", "url": "http://takahiro-saeki.github.io/new-book/template/" },
+      { "label": "GitHub", "url": "https://github.com/takahiro-saeki", "icon": "github" },
+      { "label": "dev.to", "url": "https://dev.to/hirodeath", "icon": "devto" },
+      { "label": "Qiita", "url": "https://qiita.com/hiro123", "icon": "qiita" }
+    ]
+  }
+}

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -1,17 +1,24 @@
 // 文言データの型付きローダー。
-// 将来 en.json を追加したら Locale を 'ja' | 'en' に拡張し、下記 map に足すだけで切替可能になる。
+// 言語を追加する場合は Locale を拡張し、対応する JSON を下記 map に登録するだけでよい。
 
 import ja from './ja.json'
+import en from './en.json'
 import type { Locale, SiteContent } from './types'
 
 const content: Record<Locale, SiteContent> = {
   ja: ja as SiteContent,
+  en: en as SiteContent,
 }
 
 export const defaultLocale: Locale = 'ja'
+export const locales: Locale[] = ['ja', 'en']
+
+export function isLocale(value: unknown): value is Locale {
+  return value === 'ja' || value === 'en'
+}
 
 export function getContent(locale: Locale = defaultLocale): SiteContent {
-  return content[locale]
+  return content[locale] ?? content[defaultLocale]
 }
 
 export type { Locale, SiteContent } from './types'

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -1,6 +1,6 @@
 // サイト文言の型定義。将来の英語版追加時は Locale を拡張し、en.json を足すだけで済む。
 
-export type Locale = 'ja'
+export type Locale = 'ja' | 'en'
 
 export interface NavItem {
   label: string


### PR DESCRIPTION
## 概要

サイトの英語版に対応しました。既定は日本語で、URLパラメータとブラウザ言語で表示言語を切り替えます（静的エクスポートのままクエリ文字列で実現）。

## 言語判定ルール

優先順位: **URLパラメータ `?lang=` → ブラウザ言語 → 既定(日本語)**

| ケース | 結果 |
|---|---|
| `?lang=en` | 英語（ブラウザ言語に関係なく優先） |
| `?lang=ja` | 日本語（同上） |
| パラメータなし・英語ブラウザ | 英語（自動判定） |
| パラメータなし・日本語/その他ブラウザ | 日本語（既定） |

- 言語切替時に `?lang=` を更新（共有・リロード時に維持）
- `<html lang>` を現在の言語に同期（アクセシビリティ）

## 変更内容

- `src/content/en.json` — 全文言の英語版を追加（Hero / Works / Skills / Timeline / Contact / Footer、経歴13件含む）
- `src/content/types.ts` — `Locale` を `'ja' | 'en'` に拡張
- `src/content/index.ts` — `en` を登録、`isLocale` / `locales` を追加
- `src/components/chakra/LocaleContext.tsx`（新規）— `LocaleProvider` / `useLocale` / `useContent`
- ヘッダーに **JA/EN トグル** を追加
- 各セクションを `getContent()` → `useContent()` に変更

## 確認済み

- `npm run lint` / `npx tsc --noEmit` / `npm run build`（静的エクスポート）通過
- ローカルで検証:
  - 既定=日本語、JA/ENトグルで全セクション切替、`?lang=en` 直アクセスで英語表示
  - `<html lang>` 同期、URLパラメータ更新、コンソールエラーなし
  - 言語判定ロジックを全ケース検証（param優先 / 英語ブラウザ=en / それ以外=ja）

## 補足

- クライアント側判定のため、英語ブラウザでは初回に一瞬日本語→英語へ切り替わります（静的HTMLは既定=日本語で配信のため。SEO重視の別URL方式ではなくクライアント切替方式を採用）。
- 英語の文言は翻訳ドラフトです。表現の調整希望があれば `src/content/en.json` で編集できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhARrEUnhtgbMHUReFeKnZ